### PR TITLE
Fix 24‑hour input for word clock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/tests/test_update_clock_specified_time.py
+++ b/tests/test_update_clock_specified_time.py
@@ -1,0 +1,24 @@
+import unittest
+import word_clock
+
+class DummyDot:
+    def configure(self, **kwargs):
+        pass
+
+class TestUpdateClockSpecifiedTime(unittest.TestCase):
+    def test_handles_24_hour_input(self):
+        wc = word_clock.WordClock.__new__(word_clock.WordClock)
+        wc.specified_time = '13:15'
+        wc.letters = []
+        wc.dots = [DummyDot() for _ in range(4)]
+        wc.reset_labels = lambda: None
+        wc.highlight_word = lambda word: None
+        # Bind method from class
+        wc.get_time_representation = word_clock.WordClock.get_time_representation.__get__(wc)
+        try:
+            word_clock.WordClock.update_clock(wc)
+        except KeyError:
+            self.fail('update_clock raised KeyError for 24-hour time input')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/word_clock.py
+++ b/word_clock.py
@@ -157,6 +157,9 @@ class WordClock(tk.Tk):
         """
         if self.specified_time:
             hour, minute = map(int, self.specified_time.split(':'))
+            hour = hour % 12
+            if hour == 0:
+                hour = 12
         else:
             current_time = time.localtime()
             hour = current_time.tm_hour % 12


### PR DESCRIPTION
## Summary
- handle 24‑hour input when a specific time is provided
- add regression test for the bug
- ignore generated caches

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414d3e03f88324b8018372b061cf5a