### PR TITLE
Add tests and 24h time fix

### DIFF
--- a/tests/test_word_clock.py
+++ b/tests/test_word_clock.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from word_clock import WordClock
+
+
+def get_representation(hour, minute):
+    wc = WordClock.__new__(WordClock)
+    return wc.get_time_representation(hour, minute)
+
+
+def test_three_oclock():
+    assert get_representation(3, 0) == ["IT", "IS", "OCLOCK", "THREE"]
+
+
+def test_fourteen_twentyfive():
+    assert get_representation(14, 25) == ["TWENTY", "FIVE", "PAST", "TWO"]
+
+
+def test_twenty_three_fifty_nine():
+    assert get_representation(23, 59) == ["FIVE", "TO", "TWELVE"]
+
+
+def test_24_hour_conversion():
+    # 15:00 should be represented as three o'clock
+    assert get_representation(15, 0) == ["IT", "IS", "OCLOCK", "THREE"]

--- a/word_clock.py
+++ b/word_clock.py
@@ -101,6 +101,10 @@ class WordClock(tk.Tk):
         """
         Returns the words to highlight based on the current hour and minute.
         """
+        # Normalize the hour so 24-hour input is converted to 12-hour format.
+        hour = hour % 12
+        if hour == 0:
+            hour = 12
         self.words_to_highlight = []
 
         # Always add "IT IS" at the beginning if it's exactly on the hour


### PR DESCRIPTION
## Summary
- handle 24‑hour times inside `get_time_representation`
- add pytest suite verifying several times and 24‑hour inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841662141e08324bedaaafa822590d7