### PR TITLE
Fix word clock duplicate highlights

### DIFF
--- a/tests/test_word_clock.py
+++ b/tests/test_word_clock.py
@@ -26,3 +26,13 @@ def test_twenty_three_fifty_nine():
 def test_24_hour_conversion():
     # 15:00 should be represented as three o'clock
     assert get_representation(15, 0) == ["IT", "IS", "OCLOCK", "THREE"]
+
+
+def test_seventeen_fiftyfive():
+    # 5:55 PM should highlight FIVE TO SIX
+    assert get_representation(17, 55) == ["FIVE", "TO", "SIX"]
+
+
+def test_four_fiftyfive():
+    # 4:55 should highlight FIVE TO FIVE with both FIVEs at different positions
+    assert get_representation(4, 55) == ["FIVE", "TO", "FIVE"]


### PR DESCRIPTION
## Summary
- ensure only the correct occurrence of words like FIVE and TEN are highlighted
- mark the hour word when iterating through the phrase and support old highlight_word implementations
- add regression tests for 5:55 PM and 4:55 AM/PM

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68432cf08d808324bd175de5e7e398d0