### PR TITLE
Fix path in update clock test

### DIFF
--- a/tests/test_update_clock_specified_time.py
+++ b/tests/test_update_clock_specified_time.py
@@ -1,4 +1,8 @@
+import os
+import sys
 import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import word_clock
 
 class DummyDot:


### PR DESCRIPTION
## Summary
- fix import path in update-clock specified time test so running tests from any directory works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d266a914832482211e4a333e4e33