### PR TITLE
Validate specified HH:MM input for WordClock updates

### DIFF
--- a/tests/test_word_clock.py
+++ b/tests/test_word_clock.py
@@ -36,3 +36,17 @@ def test_seventeen_fiftyfive():
 def test_four_fiftyfive():
     # 4:55 should highlight FIVE TO FIVE with both FIVEs at different positions
     assert get_representation(4, 55) == ["FIVE", "TO", "FIVE"]
+
+
+def test_parse_specified_time_accepts_24_hour_boundaries():
+    assert WordClock.parse_specified_time("00:00") == (0, 0)
+    assert WordClock.parse_specified_time("23:59") == (23, 59)
+
+
+def test_parse_specified_time_rejects_invalid_values():
+    with pytest.raises(ValueError):
+        WordClock.parse_specified_time("24:00")
+    with pytest.raises(ValueError):
+        WordClock.parse_specified_time("13:99")
+    with pytest.raises(ValueError):
+        WordClock.parse_specified_time("bad-input")

--- a/word_clock.py
+++ b/word_clock.py
@@ -163,12 +163,29 @@ class WordClock(tk.Tk):
 
         return self.words_to_highlight
 
+    @staticmethod
+    def parse_specified_time(specified_time):
+        """
+        Parse a specified time in HH:MM format and validate ranges.
+        """
+        try:
+            hour_text, minute_text = specified_time.split(':')
+            hour = int(hour_text)
+            minute = int(minute_text)
+        except (ValueError, AttributeError):
+            raise ValueError("specified_time must be in HH:MM format") from None
+
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            raise ValueError("specified_time must be within 00:00-23:59")
+
+        return hour, minute
+
     def update_clock(self):
         """
         Updates the word clock to reflect the current time.
         """
         if self.specified_time:
-            hour, minute = map(int, self.specified_time.split(':'))
+            hour, minute = self.parse_specified_time(self.specified_time)
             hour = hour % 12
             if hour == 0:
                 hour = 12


### PR DESCRIPTION
### Motivation
- The `update_clock` logic previously parsed `specified_time` with a raw `split(':')`/`int` conversion and no range checks, which could permit malformed or out-of-range inputs to cause unexpected errors.

### Description
- Add a new static helper `parse_specified_time(specified_time)` that validates `HH:MM` format and enforces 24-hour bounds (`00:00`–`23:59`).
- Use `parse_specified_time` inside `update_clock` instead of `map(int, specified_time.split(':'))` to centralize parsing and validation.
- Add unit tests in `tests/test_word_clock.py` to cover valid boundary inputs (`"00:00"`, `"23:59"`) and invalid inputs (`"24:00"`, `"13:99"`, `"bad-input"`).

### Testing
- Ran the test suite with `pytest -q`, all tests passed (`9 passed`).
- Attempted a headless GUI smoke test with `xvfb-run`, but `xvfb-run` is not installed in this environment so that step could not run.
- A direct attempt to instantiate the Tk UI failed in this environment due to no display (`$DISPLAY` unset), which is an environment limitation rather than a code failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c408d734b08324b5c2c5dd6b183311)