### PR TITLE
Add specified_time parsing/validation, tests, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Word Clock
+
+A simple Tkinter-based word clock that displays time as words (for example, **"TWENTY FIVE PAST TWO"**) with four dots to indicate extra minutes between 5-minute intervals.
+
+## Features
+
+- 10x11 letter grid with highlighted words for the current time
+- 4 minute dots for minutes not divisible by 5
+- Supports both live local time and a fixed `HH:MM` input for testing/demo
+- Handles 24-hour input by converting to 12-hour word output
+
+## Requirements
+
+- Python 3.10+
+- Tkinter (typically bundled with standard Python installs)
+
+## Run
+
+### Live clock
+
+```bash
+python word_clock.py
+```
+
+### Fixed time (24-hour `HH:MM`)
+
+```bash
+python word_clock.py 13:15
+```
+
+The fixed-time mode validates input and accepts only values from `00:00` to `23:59`.
+
+## Test
+
+```bash
+pytest -q
+```
+
+## Notes for headless environments
+
+This project uses Tkinter and requires a display server to render the UI. In headless CI/container environments without `$DISPLAY`, UI instantiation will fail even when logic tests pass.

--- a/tests/test_word_clock.py
+++ b/tests/test_word_clock.py
@@ -36,3 +36,17 @@ def test_seventeen_fiftyfive():
 def test_four_fiftyfive():
     # 4:55 should highlight FIVE TO FIVE with both FIVEs at different positions
     assert get_representation(4, 55) == ["FIVE", "TO", "FIVE"]
+
+
+def test_parse_specified_time_accepts_24_hour_boundaries():
+    assert WordClock.parse_specified_time("00:00") == (0, 0)
+    assert WordClock.parse_specified_time("23:59") == (23, 59)
+
+
+def test_parse_specified_time_rejects_invalid_values():
+    with pytest.raises(ValueError):
+        WordClock.parse_specified_time("24:00")
+    with pytest.raises(ValueError):
+        WordClock.parse_specified_time("13:99")
+    with pytest.raises(ValueError):
+        WordClock.parse_specified_time("bad-input")

--- a/word_clock.py
+++ b/word_clock.py
@@ -163,12 +163,29 @@ class WordClock(tk.Tk):
 
         return self.words_to_highlight
 
+    @staticmethod
+    def parse_specified_time(specified_time):
+        """
+        Parse a specified time in HH:MM format and validate ranges.
+        """
+        try:
+            hour_text, minute_text = specified_time.split(':')
+            hour = int(hour_text)
+            minute = int(minute_text)
+        except (ValueError, AttributeError):
+            raise ValueError("specified_time must be in HH:MM format") from None
+
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            raise ValueError("specified_time must be within 00:00-23:59")
+
+        return hour, minute
+
     def update_clock(self):
         """
         Updates the word clock to reflect the current time.
         """
         if self.specified_time:
-            hour, minute = map(int, self.specified_time.split(':'))
+            hour, minute = self.parse_specified_time(self.specified_time)
             hour = hour % 12
             if hour == 0:
                 hour = 12


### PR DESCRIPTION
### Motivation

- Make the CLI "fixed time" mode robust by validating `HH:MM` input and centralizing parsing logic. 
- Provide project documentation for running the app and tests. 
- Add unit coverage for the new parsing behavior to prevent invalid inputs from being accepted.

### Description

- Added `README.md` with usage, requirements, testing instructions, and headless environment notes. 
- Implemented `WordClock.parse_specified_time(specified_time)` to parse and validate `HH:MM` inputs and integrated it into `update_clock`. 
- Updated `word_clock.py` to use the new parser when `specified_time` is provided and performed small code cleanups. 
- Added tests `test_parse_specified_time_accepts_24_hour_boundaries` and `test_parse_specified_time_rejects_invalid_values` to `tests/test_word_clock.py`.

### Testing

- Ran unit tests with `pytest -q`, and the test suite passed. 
- Existing time-representation tests (`test_three_oclock`, `test_fourteen_twentyfive`, etc.) were executed as part of the run and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c408d734b08324b5c2c5dd6b183311)